### PR TITLE
Add failing test

### DIFF
--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -139,7 +139,7 @@ export class Rifm extends React.Component<Props, State> {
       }
 
       // format usually looks better without this
-      if (this.props.replace && (_state.op || _state.del)) {
+      if (this.props.replace && (_state.op || (_state.del && !_state.di))) {
         while (
           value[start + 1] &&
           (this.props.refuse || /[^\d]+/).test(value[start + 1])

--- a/tests/RifmMask.test.js
+++ b/tests/RifmMask.test.js
@@ -190,6 +190,9 @@ test('mask behaviour with delete', async () => {
   exec({ type: 'DELETE' });
   exec({ type: 'DELETE' });
   exec({ type: 'DELETE' });
+  exec({ type: 'PUT_SYMBOL', payload: '78' });
+  exec({ type: 'MOVE_CARET', payload: -5 });
+  exec({ type: 'DELETE' });
 
   expect(snaphot).toMatchSnapshot();
 });

--- a/tests/__snapshots__/RifmMask.test.js.snap
+++ b/tests/__snapshots__/RifmMask.test.js.snap
@@ -496,5 +496,34 @@ Array [
     "value": "18-08-19",
     "withCaret": "18-08-19|",
   },
+  Object {
+    "cmd": Object {
+      "payload": "78",
+      "type": "PUT_SYMBOL",
+    },
+    "selectionEnd": 10,
+    "selectionStart": 10,
+    "value": "18-08-1978",
+    "withCaret": "18-08-1978|",
+  },
+  Object {
+    "cmd": Object {
+      "payload": -5,
+      "type": "MOVE_CARET",
+    },
+    "selectionEnd": 5,
+    "selectionStart": 5,
+    "value": "18-08-1978",
+    "withCaret": "18-08|-1978",
+  },
+  Object {
+    "cmd": Object {
+      "type": "DELETE",
+    },
+    "selectionEnd": 6,
+    "selectionStart": 6,
+    "value": "18-08-1978",
+    "withCaret": "18-08-|1978",
+  },
 ]
 `;


### PR DESCRIPTION
`18-08|-1978` where `|` is cursor, delete causes cursor move in incorrect position `18-08-1|978`

must be `18-08-|1978`