### PR TITLE
autoformat passed value

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,22 +1,22 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 6681,
-    "minified": 1656,
+    "bundled": 6697,
+    "minified": 1648,
     "gzipped": 820
   },
   "dist/rifm.min.js": {
-    "bundled": 6467,
-    "minified": 1515,
-    "gzipped": 741
+    "bundled": 6483,
+    "minified": 1507,
+    "gzipped": 743
   },
   "dist/rifm.cjs.js": {
-    "bundled": 6233,
-    "minified": 1582,
-    "gzipped": 795
+    "bundled": 6249,
+    "minified": 1574,
+    "gzipped": 792
   },
   "dist/rifm.esm.js": {
-    "bundled": 6162,
-    "minified": 1519,
+    "bundled": 6178,
+    "minified": 1511,
     "gzipped": 749,
     "treeshaked": {
       "rollup": {
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 5876,
-    "minified": 1304,
-    "gzipped": 627,
+    "bundled": 5892,
+    "minified": 1296,
+    "gzipped": 629,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/pages/date-format/index.js
+++ b/pages/date-format/index.js
@@ -53,7 +53,7 @@ const Example = () /*:React.Node*/ => {
           accept={/\d/g}
           replace={v => 10 <= v.length}
           format={formatDate}
-          value={formatDate(formatted)}
+          value={formatted}
           onChange={setFormatted}
         >
           {renderInput}
@@ -66,7 +66,7 @@ const Example = () /*:React.Node*/ => {
           accept={/[\d-]+/g}
           replace={v => 10 <= v.length}
           format={formatDateOther}
-          value={formatDateOther(formattedA)}
+          value={formattedA}
           onChange={setFormattedA}
         >
           {renderInput}
@@ -78,7 +78,7 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/[\d]/g}
           format={formatDateWithMask}
-          value={formatDateWithMask(masked)}
+          value={masked}
           onChange={setMasked}
         >
           {renderInput}

--- a/pages/number-format/index.js
+++ b/pages/number-format/index.js
@@ -126,7 +126,7 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/\d/g}
           format={formatInteger}
-          value={formatInteger(integer)}
+          value={integer}
           onChange={value => setInteger(parseInteger(value))}
         >
           {renderInput}
@@ -138,7 +138,7 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/[\d-]/g}
           format={formatNegative}
-          value={formatNegative(negative)}
+          value={negative}
           onChange={value => setNegative(parseNegative(value))}
         >
           {renderInput}
@@ -151,7 +151,7 @@ const Example = () /*:React.Node*/ => {
           accept={/[\d.]/g}
           format={v => formatFixedPointNumber(v, 2)}
           // 00 is needed here see disadvantages comment at formatNumber
-          value={formatFixedPointNumber(`${fixedFloat}00`, 2)}
+          value={`${fixedFloat}00`}
           onChange={value => setFixedFloat(parseNumber(value))}
         >
           {renderInput}
@@ -163,7 +163,7 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/[\d.]/g}
           format={v => formatFloatingPointNumber(v, 2)}
-          value={formatFloatingPointNumber(variableFloat, 2)}
+          value={variableFloat}
           onChange={value => setVariableFloat(parseNumber(value))}
         >
           {renderInput}
@@ -175,7 +175,7 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/[\d.]/g}
           format={formatMeters}
-          value={formatMeters(variableFloat)}
+          value={variableFloat}
           onChange={value => setVariableFloat(parseNumber(value))}
         >
           {renderInput}
@@ -188,7 +188,7 @@ const Example = () /*:React.Node*/ => {
           // $ need to be in regexp to prevent cursor jumping on backspace
           accept={/[\d.$]/g}
           format={formatCurrency}
-          value={formatCurrency(variableFloat)}
+          value={variableFloat}
           onChange={value => setVariableFloat(parseNumber(value))}
         >
           {renderInput}

--- a/pages/phone-format/index.js
+++ b/pages/phone-format/index.js
@@ -13,7 +13,7 @@ const formatPhone = string => {
 };
 
 const Example = () /*:React.Node*/ => {
-  const [phone, setPhone] = React.useState('');
+  const [phone, setPhone] = React.useState('1234567');
 
   return (
     <Grid>
@@ -28,7 +28,7 @@ const Example = () /*:React.Node*/ => {
               : v => v.length >= 14
           }
           format={formatPhone}
-          value={formatPhone(phone)}
+          value={phone}
           onChange={setPhone}
         >
           {renderInput}

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -19,6 +19,7 @@ type Props = {|
 export const Rifm = (props: Props) => {
   const [, refresh] = React.useReducer(c => c + 1, 0);
   const valueRef = React.useRef(null);
+  const userValue = props.format(props.value);
 
   // state of delete button see comments below about inputType support
   const isDeleleteButtonDownRef = React.useRef(false);
@@ -35,15 +36,14 @@ export const Rifm = (props: Props) => {
       }
     }
 
-    const value = props.value;
     const eventValue = evt.target.value;
 
     valueRef.current = [
       eventValue, // eventValue
       evt.target, // input
-      eventValue.length > value.length, // isSizeIncreaseOperation
+      eventValue.length > userValue.length, // isSizeIncreaseOperation
       isDeleleteButtonDownRef.current, // isDeleleteButtonDown
-      value === props.format(eventValue), // isNoOperation
+      userValue === props.format(eventValue), // isNoOperation
     ];
 
     // The main trick is to update underlying input with non formatted value (= eventValue)
@@ -103,7 +103,7 @@ export const Rifm = (props: Props) => {
       // we need to replace symbols instead of do nothing as like in format
       if (
         props.replace &&
-        props.replace(props.value) &&
+        props.replace(userValue) &&
         isSizeIncreaseOperation &&
         !isNoOperation
       ) {
@@ -119,8 +119,8 @@ export const Rifm = (props: Props) => {
 
       const formattedValue = props.format(eventValue);
 
-      if (props.value === formattedValue) {
-        // if nothing changed for formatted value, just refresh so props.value will be used at render
+      if (userValue === formattedValue) {
+        // if nothing changed for formatted value, just refresh so userValue will be used at render
         refresh();
       } else {
         props.onChange(formattedValue);
@@ -176,7 +176,7 @@ export const Rifm = (props: Props) => {
   }, []);
 
   return props.children({
-    value: valueRef.current != null ? valueRef.current[0] : props.value,
+    value: valueRef.current != null ? valueRef.current[0] : userValue,
     onChange,
   });
 };

--- a/tests/RifmFormat.test.js
+++ b/tests/RifmFormat.test.js
@@ -102,13 +102,11 @@ test('format with fixed point delete backspace', async () => {
     format,
   });
 
-  exec({ type: 'MOVE_CARET', payload: 1 }).toMatchInlineSnapshot(`"0|.00"`);
-  exec({ type: 'PUT_SYMBOL', payload: '1' }).toMatchInlineSnapshot(`"1.0|0"`);
-  exec({ type: 'MOVE_CARET', payload: -1 }).toMatchInlineSnapshot(`"1.|00"`);
-  exec({ type: 'PUT_SYMBOL', payload: '23' }).toMatchInlineSnapshot(`"1.23|"`);
-  exec({ type: 'MOVE_CARET', payload: -2 }).toMatchInlineSnapshot(`"1.|23"`);
-  exec({ type: 'BACKSPACE' }).toMatchInlineSnapshot(`"1|.23"`);
-  exec({ type: 'DELETE' }).toMatchInlineSnapshot(`"1.|23"`);
+  exec({ type: 'MOVE_CARET', payload: 2 }).toMatchInlineSnapshot(`"0.|00"`);
+  exec({ type: 'PUT_SYMBOL', payload: '23' }).toMatchInlineSnapshot(`"0.23|"`);
+  exec({ type: 'MOVE_CARET', payload: -2 }).toMatchInlineSnapshot(`"0.|23"`);
+  exec({ type: 'BACKSPACE' }).toMatchInlineSnapshot(`"0|.23"`);
+  exec({ type: 'DELETE' }).toMatchInlineSnapshot(`"0.|23"`);
 });
 
 test('format works even if state is not updated on equal vals', async () => {

--- a/tests/RifmFormat.test.js
+++ b/tests/RifmFormat.test.js
@@ -102,7 +102,10 @@ test('format with fixed point delete backspace', async () => {
     format,
   });
 
-  exec({ type: 'PUT_SYMBOL', payload: '123' }).toMatchInlineSnapshot(`"1.23|"`);
+  exec({ type: 'MOVE_CARET', payload: 1 }).toMatchInlineSnapshot(`"0|.00"`);
+  exec({ type: 'PUT_SYMBOL', payload: '1' }).toMatchInlineSnapshot(`"1.0|0"`);
+  exec({ type: 'MOVE_CARET', payload: -1 }).toMatchInlineSnapshot(`"1.|00"`);
+  exec({ type: 'PUT_SYMBOL', payload: '23' }).toMatchInlineSnapshot(`"1.23|"`);
   exec({ type: 'MOVE_CARET', payload: -2 }).toMatchInlineSnapshot(`"1.|23"`);
   exec({ type: 'BACKSPACE' }).toMatchInlineSnapshot(`"1|.23"`);
   exec({ type: 'DELETE' }).toMatchInlineSnapshot(`"1.|23"`);

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -23,7 +23,7 @@ export const createExec = (props: Props) => {
   TestRenderer.create(
     <Value initial={''}>
       {input => {
-        stateValue_ = props.format(input.value);
+        stateValue_ = input.value;
 
         return (
           <Rifm value={input.value} onChange={input.set} {...props}>
@@ -51,11 +51,11 @@ export const createExec = (props: Props) => {
       execCommand(cmd);
     });
 
-    if (!getVal) {
+    if (getVal == null || stateValue_ == null) {
       throw Error('rifm is not initialized');
     }
 
-    expect(stateValue_).toEqual(getVal().value);
+    expect(props.format(stateValue_)).toEqual(getVal().value);
 
     return expect(renderInputState(getVal()));
   };

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -23,7 +23,7 @@ export const createExec = (props: Props) => {
   TestRenderer.create(
     <Value initial={''}>
       {input => {
-        stateValue_ = input.value;
+        stateValue_ = props.format(input.value);
 
         return (
           <Rifm value={input.value} onChange={input.set} {...props}>


### PR DESCRIPTION
In all our cases format is required to get correct initial value. We
decided to do it our of the box to reduce boilerplate required from user.

Previously you had to write this
```js
<Rifm
  accept={/\d/g}
  format={formatNumber}
  value={formatNumber(number)}
  onChange={value => setNumber(parseNumber(value))}
>
  {renderInput}
</Rifm>
```

Now it's enough to use format only once
```js
<Rifm
  accept={/\d/g}
  format={formatNumber}
  value={number}
  onChange={value => setNumber(parseNumber(value))}
>
  {renderInput}
</Rifm>
```