### PR TITLE
Remove replace from code

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/.*\(test\).*\.json$
+.*/out/*
 
 [include]
 

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 7497,
-    "minified": 1733,
+    "bundled": 7480,
+    "minified": 1724,
     "gzipped": 858
   },
   "dist/rifm.min.js": {
-    "bundled": 7283,
-    "minified": 1592,
+    "bundled": 7266,
+    "minified": 1583,
     "gzipped": 780
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7025,
-    "minified": 1659,
-    "gzipped": 832
+    "bundled": 7008,
+    "minified": 1650,
+    "gzipped": 831
   },
   "dist/rifm.esm.js": {
-    "bundled": 6954,
-    "minified": 1596,
-    "gzipped": 786,
+    "bundled": 6937,
+    "minified": 1587,
+    "gzipped": 787,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 6668,
-    "minified": 1381,
-    "gzipped": 665,
+    "bundled": 6651,
+    "minified": 1372,
+    "gzipped": 664,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/pages/date-format/index.js
+++ b/pages/date-format/index.js
@@ -51,7 +51,7 @@ const Example = () /*:React.Node*/ => {
         <div>Date format</div>
         <Rifm
           accept={/\d/g}
-          replace={v => 10 <= v.length}
+          mask={10 <= formatted.length}
           format={formatDate}
           value={formatted}
           onChange={setFormatted}
@@ -64,7 +64,7 @@ const Example = () /*:React.Node*/ => {
         <div>Date format another</div>
         <Rifm
           accept={/[\d-]+/g}
-          replace={v => 10 <= v.length}
+          mask={10 <= formatted.length}
           format={formatDateOther}
           value={formattedA}
           onChange={setFormattedA}

--- a/pages/phone-format/index.js
+++ b/pages/phone-format/index.js
@@ -22,10 +22,10 @@ const Example = () /*:React.Node*/ => {
         <Rifm
           accept={/\d+/g}
           // do not jump after ) until see number before
-          replace={
+          mask={
             phone.length < 6 && /[^\d]+/.test(phone[3])
               ? undefined
-              : v => v.length >= 14
+              : phone.length >= 14
           }
           format={formatPhone}
           value={phone}

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -6,7 +6,7 @@ type Props = {|
   value: string,
   onChange: string => void,
   format: (str: string) => string,
-  replace?: string => boolean,
+  mask?: boolean,
   accept?: RegExp,
   children: ({
     value: string,
@@ -120,12 +120,7 @@ export const Rifm = (props: Props) => {
 
       // Masking part, for masks if size of mask is above some value (props.replace checks that)
       // we need to replace symbols instead of do nothing as like in format
-      if (
-        props.replace &&
-        props.replace(userValue) &&
-        isSizeIncreaseOperation &&
-        !isNoOperation
-      ) {
+      if (props.mask === true && isSizeIncreaseOperation && !isNoOperation) {
         let start = getCursorPosition(eventValue);
 
         const c = clean(eventValue.substr(start))[0];
@@ -153,7 +148,7 @@ export const Rifm = (props: Props) => {
         // as an example date mask: was "5|1-24-3" then user pressed "6"
         // it becomes "56-|12-43" with this code, and "56|-12-43" without
         if (
-          props.replace &&
+          props.mask != null &&
           (isSizeIncreaseOperation || (isDeleleteButtonDown && !deleteWasNoOp))
         ) {
           while (formattedValue[start] && clean(formattedValue[start]) === '') {

--- a/tests/RifmMask.test.js
+++ b/tests/RifmMask.test.js
@@ -5,7 +5,7 @@ import { createExec } from './utils/exec';
 
 test('mask behaviour', async () => {
   const exec = createExec({
-    replace: v => v.length >= 10,
+    maskFn: v => v.length >= 10,
     format: dateFormat,
   });
 
@@ -53,7 +53,7 @@ test('mask behaviour', async () => {
 
 test('mask behaviour with bad symbols', async () => {
   const exec = createExec({
-    replace: v => v.length >= 10,
+    mask: true,
     format: dateFormat,
   });
 
@@ -64,7 +64,7 @@ test('mask behaviour with bad symbols', async () => {
 
 test('mask behaviour with delete', async () => {
   const exec = createExec({
-    replace: v => v.length >= 10,
+    maskFn: v => v.length >= 10,
     format: dateFormat,
   });
 
@@ -95,7 +95,7 @@ test('mask behaviour with delete', async () => {
 
 test('mask works even if state is not updated on equal vals', async () => {
   const exec = createExec({
-    replace: v => v.length >= 10,
+    mask: true,
     format: dateFormat,
   });
 

--- a/tests/testFlow.js
+++ b/tests/testFlow.js
@@ -14,7 +14,7 @@ export const TestFlow = () => (
     {text => (
       <Rifm
         accept={/\d/g}
-        replace={undefined}
+        mask={undefined}
         value={text.value}
         onChange={text.set}
         format={numberFormat}

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -11,8 +11,10 @@ import {
 
 type Props = {|
   accept?: RegExp,
-  replace?: string => boolean,
+  // replace?: string => boolean,
+  mask?: boolean,
   format: (str: string) => string,
+  maskFn?: string => boolean,
 |};
 
 export const createExec = (props: Props) => {
@@ -26,7 +28,19 @@ export const createExec = (props: Props) => {
         stateValue_ = input.value;
 
         return (
-          <Rifm value={input.value} onChange={input.set} {...props}>
+          <Rifm
+            value={input.value}
+            onChange={input.set}
+            accept={props.accept}
+            format={props.format}
+            mask={
+              props.mask != null
+                ? props.mask
+                : props.maskFn != null
+                ? props.maskFn(input.value)
+                : undefined
+            }
+          >
             {({ value, onChange }) => (
               <InputEmulator value={value} onChange={onChange}>
                 {(exec, val) => {


### PR DESCRIPTION
Rifm lost nothing if switch replace with boolean mask attribute, which instead of function can calculate does mask mode is on.

So it was
```
replace={v => v.length > 14}
```

become
```
mask={value.length > 14}
```

and looks like in most cases it will be

```
mask={true}
```