### PR TITLE
Generalisation of lowercase etc enforcements on inputs

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 8089,
-    "minified": 2023,
-    "gzipped": 987
+    "bundled": 8037,
+    "minified": 1971,
+    "gzipped": 967
   },
   "dist/rifm.min.js": {
     "bundled": 7216,
@@ -10,14 +10,14 @@
     "gzipped": 779
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7794,
-    "minified": 2077,
-    "gzipped": 975
+    "bundled": 7742,
+    "minified": 2025,
+    "gzipped": 957
   },
   "dist/rifm.esm.js": {
-    "bundled": 7723,
-    "minified": 2014,
-    "gzipped": 933,
+    "bundled": 7671,
+    "minified": 1962,
+    "gzipped": 914,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 7480,
-    "minified": 1724,
-    "gzipped": 858
+    "bundled": 8089,
+    "minified": 2023,
+    "gzipped": 987
   },
   "dist/rifm.min.js": {
-    "bundled": 7266,
-    "minified": 1583,
-    "gzipped": 780
+    "bundled": 7216,
+    "minified": 1570,
+    "gzipped": 779
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7008,
-    "minified": 1650,
-    "gzipped": 831
+    "bundled": 7794,
+    "minified": 2077,
+    "gzipped": 975
   },
   "dist/rifm.esm.js": {
-    "bundled": 6937,
-    "minified": 1587,
-    "gzipped": 787,
+    "bundled": 7723,
+    "minified": 2014,
+    "gzipped": 933,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 6651,
-    "minified": 1372,
-    "gzipped": 664,
+    "bundled": 6597,
+    "minified": 1359,
+    "gzipped": 663,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 8029,
-    "minified": 1965,
-    "gzipped": 965
+    "bundled": 8097,
+    "minified": 1984,
+    "gzipped": 973
   },
   "dist/rifm.min.js": {
-    "bundled": 7208,
-    "minified": 1564,
-    "gzipped": 777
+    "bundled": 7276,
+    "minified": 1583,
+    "gzipped": 783
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7726,
-    "minified": 2013,
-    "gzipped": 955
+    "bundled": 7780,
+    "minified": 2016,
+    "gzipped": 961
   },
   "dist/rifm.esm.js": {
-    "bundled": 7655,
-    "minified": 1950,
-    "gzipped": 912,
+    "bundled": 7709,
+    "minified": 1953,
+    "gzipped": 917,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 6589,
-    "minified": 1353,
-    "gzipped": 662,
+    "bundled": 6655,
+    "minified": 1372,
+    "gzipped": 667,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 8037,
-    "minified": 1971,
-    "gzipped": 967
+    "bundled": 8029,
+    "minified": 1965,
+    "gzipped": 965
   },
   "dist/rifm.min.js": {
-    "bundled": 7216,
-    "minified": 1570,
-    "gzipped": 779
+    "bundled": 7208,
+    "minified": 1564,
+    "gzipped": 777
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7742,
-    "minified": 2025,
-    "gzipped": 957
+    "bundled": 7726,
+    "minified": 2013,
+    "gzipped": 955
   },
   "dist/rifm.esm.js": {
-    "bundled": 7671,
-    "minified": 1962,
-    "gzipped": 914,
+    "bundled": 7655,
+    "minified": 1950,
+    "gzipped": 912,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 6597,
-    "minified": 1359,
-    "gzipped": 663,
+    "bundled": 6589,
+    "minified": 1353,
+    "gzipped": 662,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/pages/case-enforcement/index.js
+++ b/pages/case-enforcement/index.js
@@ -9,6 +9,7 @@ const Example = () /*:React.Node*/ => {
   const [uppercase, setUppercase] = React.useState('');
   const [capitalized, setCapitalized] = React.useState('');
   const [latinLetters, setLatinLetters] = React.useState('');
+  const [comment, setComment] = React.useState('');
 
   return (
     <Grid>
@@ -73,8 +74,8 @@ const Example = () /*:React.Node*/ => {
               .repeat(20)
               .slice(0, v.length)
           }
-          value={capitalized}
-          onChange={setCapitalized}
+          value={comment}
+          onChange={setComment}
         >
           {renderInput}
         </Rifm>

--- a/pages/case-enforcement/index.js
+++ b/pages/case-enforcement/index.js
@@ -16,7 +16,8 @@ const Example = () /*:React.Node*/ => {
         <div>Lower case</div>
         <Rifm
           accept={/./g}
-          format={v => v.toLowerCase()}
+          format={v => v}
+          replace={v => v.toLowerCase()}
           value={lowercase}
           onChange={setLowercase}
         >
@@ -28,7 +29,8 @@ const Example = () /*:React.Node*/ => {
         <div>Upper case</div>
         <Rifm
           accept={/./g}
-          format={v => v.toUpperCase()}
+          format={v => v}
+          replace={v => v.toUpperCase()}
           value={uppercase}
           onChange={setUppercase}
         >
@@ -40,7 +42,8 @@ const Example = () /*:React.Node*/ => {
         <div>Capital first letter</div>
         <Rifm
           accept={/./g}
-          format={v => v.slice(0, 1).toUpperCase() + v.slice(1).toLowerCase()}
+          format={v => v}
+          replace={v => v.slice(0, 1).toUpperCase() + v.slice(1).toLowerCase()}
           value={capitalized}
           onChange={setCapitalized}
         >
@@ -55,6 +58,23 @@ const Example = () /*:React.Node*/ => {
           format={v => (v.match(/[a-zA-Z]/g) || []).join('')}
           value={latinLetters}
           onChange={setLatinLetters}
+        >
+          {renderInput}
+        </Rifm>
+      </div>
+
+      <div>
+        <div>Leave a comment about Rifm</div>
+        <Rifm
+          accept={/./g}
+          format={v => v}
+          replace={v =>
+            'Rifm is the best mask and formatting library. I love it! '
+              .repeat(20)
+              .slice(0, v.length)
+          }
+          value={capitalized}
+          onChange={setCapitalized}
         >
           {renderInput}
         </Rifm>

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -20,7 +20,10 @@ type Props = {|
 export const Rifm = (props: Props) => {
   const [, refresh] = React.useReducer(c => c + 1, 0);
   const valueRef = React.useRef(null);
-  const userValue = props.format(props.value);
+  const { replace } = props;
+  const userValue = replace
+    ? replace(props.format(props.value))
+    : props.format(props.value);
 
   // state of delete button see comments below about inputType support
   const isDeleleteButtonDownRef = React.useRef(false);
@@ -147,8 +150,8 @@ export const Rifm = (props: Props) => {
         refresh();
       } else {
         if (process.env.NODE_ENV !== 'production') {
-          const replaceValue = props.replace
-            ? props.replace(formattedValue)
+          const replaceValue = replace
+            ? replace(formattedValue)
             : formattedValue;
 
           if (replaceValue.length !== formattedValue.length) {
@@ -157,9 +160,7 @@ export const Rifm = (props: Props) => {
 
           props.onChange(replaceValue);
         } else {
-          props.onChange(
-            props.replace ? props.replace(formattedValue) : formattedValue
-          );
+          props.onChange(replace ? replace(formattedValue) : formattedValue);
         }
       }
 

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -53,10 +53,9 @@ export const Rifm = (props: Props) => {
         eventValue !== formattedEventValue &&
         eventValue.toLowerCase() === formattedEventValue.toLowerCase()
       ) {
-        console.warn(`
-          Case enforcement does not work with format.
-          Please use replace={value => value.toLowerCase()} instead
-        `);
+        console.warn(
+          'Case enforcement does not work with format. Please use replace={value => value.toLowerCase()} instead'
+        );
       }
     }
 
@@ -154,7 +153,7 @@ export const Rifm = (props: Props) => {
               : formattedValue;
 
           if (replaceValue.length !== formattedValue.length) {
-            console.warn('replace operation to work, must preserve length');
+            console.warn('replace must preserve length');
           }
 
           props.onChange(replaceValue);

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -157,11 +157,9 @@ export const Rifm = (props: Props) => {
           if (replaceValue.length !== formattedValue.length) {
             console.warn('replace must preserve length');
           }
-
-          props.onChange(replaceValue);
-        } else {
-          props.onChange(replace ? replace(formattedValue) : formattedValue);
         }
+
+        props.onChange(replace ? replace(formattedValue) : formattedValue);
       }
 
       return () => {

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -147,10 +147,9 @@ export const Rifm = (props: Props) => {
         refresh();
       } else {
         if (process.env.NODE_ENV !== 'production') {
-          const replaceValue =
-            props.replace != null
-              ? props.replace(formattedValue)
-              : formattedValue;
+          const replaceValue = props.replace
+            ? props.replace(formattedValue)
+            : formattedValue;
 
           if (replaceValue.length !== formattedValue.length) {
             console.warn('replace must preserve length');
@@ -159,9 +158,7 @@ export const Rifm = (props: Props) => {
           props.onChange(replaceValue);
         } else {
           props.onChange(
-            props.replace != null
-              ? props.replace(formattedValue)
-              : formattedValue
+            props.replace ? props.replace(formattedValue) : formattedValue
           );
         }
       }

--- a/tests/RifmFormat.test.js
+++ b/tests/RifmFormat.test.js
@@ -144,3 +144,14 @@ it('format can work with case changes', () => {
   exec({ type: 'MOVE_CARET', payload: -5 }).toMatchInlineSnapshot(`"hello |world"`);
   exec({ type: 'PUT_SYMBOL', payload: 'BeAuTiFuL ' }).toMatchInlineSnapshot(`"hello beautiful |world"`);
 });
+
+it('replace is applied to input value', () => {
+  const exec = createExec({
+    format: v => v,
+    replace: v => v.toLowerCase(),
+    accept: /.+/g,
+    initialValue: 'HeLLo',
+  });
+
+  exec({ type: 'MOVE_CARET', payload: -5 }).toMatchInlineSnapshot(`"|hello"`);
+});

--- a/tests/RifmFormat.test.js
+++ b/tests/RifmFormat.test.js
@@ -132,3 +132,15 @@ test('format works even if state is not updated on equal vals', async () => {
   exec({ type: 'PUT_SYMBOL', payload: 'x' }).toMatchInlineSnapshot(`"123|’456"`);
   exec({ type: 'PUT_SYMBOL', payload: 'x' }).toMatchInlineSnapshot(`"123|’456"`);
 });
+
+it('format can work with case changes', () => {
+  const exec = createExec({
+    format: v => v,
+    replace: v => v.toLowerCase(),
+    accept: /.+/g,
+  });
+
+  exec({ type: 'PUT_SYMBOL', payload: 'HELLO WORLD' }).toMatchInlineSnapshot(`"hello world|"`);
+  exec({ type: 'MOVE_CARET', payload: -5 }).toMatchInlineSnapshot(`"hello |world"`);
+  exec({ type: 'PUT_SYMBOL', payload: 'BeAuTiFuL ' }).toMatchInlineSnapshot(`"hello beautiful |world"`);
+});

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -14,6 +14,7 @@ type Props = {|
   // replace?: string => boolean,
   mask?: boolean,
   format: (str: string) => string,
+  replace?: (str: string) => string,
   maskFn?: string => boolean,
 |};
 
@@ -33,6 +34,7 @@ export const createExec = (props: Props) => {
             onChange={input.set}
             accept={props.accept}
             format={props.format}
+            replace={props.replace}
             mask={
               props.mask != null
                 ? props.mask

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -16,6 +16,7 @@ type Props = {|
   format: (str: string) => string,
   replace?: (str: string) => string,
   maskFn?: string => boolean,
+  initialValue?: string,
 |};
 
 export const createExec = (props: Props) => {
@@ -24,7 +25,7 @@ export const createExec = (props: Props) => {
   let stateValue_ = null;
 
   TestRenderer.create(
-    <Value initial={''}>
+    <Value initial={props.initialValue != null ? props.initialValue : ''}>
       {input => {
         stateValue_ = input.value;
 
@@ -43,15 +44,17 @@ export const createExec = (props: Props) => {
                 : undefined
             }
           >
-            {({ value, onChange }) => (
-              <InputEmulator value={value} onChange={onChange}>
-                {(exec, val) => {
-                  execCommand = exec;
-                  getVal = val;
-                  return null;
-                }}
-              </InputEmulator>
-            )}
+            {({ value, onChange }) =>
+              console.log('1', value) || (
+                <InputEmulator value={value} onChange={onChange}>
+                  {(exec, val) => {
+                    execCommand = exec;
+                    getVal = val;
+                    return null;
+                  }}
+                </InputEmulator>
+              )
+            }
           </Rifm>
         );
       }}
@@ -70,8 +73,11 @@ export const createExec = (props: Props) => {
     if (getVal == null || stateValue_ == null) {
       throw Error('rifm is not initialized');
     }
+    const { replace } = props;
 
-    expect(props.format(stateValue_)).toEqual(getVal().value);
+    expect(
+      replace ? replace(props.format(stateValue_)) : props.format(stateValue_)
+    ).toEqual(getVal().value);
 
     return expect(renderInputState(getVal()));
   };

--- a/tests/utils/exec.js
+++ b/tests/utils/exec.js
@@ -44,17 +44,15 @@ export const createExec = (props: Props) => {
                 : undefined
             }
           >
-            {({ value, onChange }) =>
-              console.log('1', value) || (
-                <InputEmulator value={value} onChange={onChange}>
-                  {(exec, val) => {
-                    execCommand = exec;
-                    getVal = val;
-                    return null;
-                  }}
-                </InputEmulator>
-              )
-            }
+            {({ value, onChange }) => (
+              <InputEmulator value={value} onChange={onChange}>
+                {(exec, val) => {
+                  execCommand = exec;
+                  getVal = val;
+                  return null;
+                }}
+              </InputEmulator>
+            )}
           </Rifm>
         );
       }}


### PR DESCRIPTION
solves #65 

`replace: str=>str` method added to Rifm, it allows to do postprocessing operation after format.

And if `replace(value).length === value.length` then replace doesn't affect cursor position.


So lowercase enforcement now look

```
        <Rifm
          accept={/./g}
          format={v => v}
          replace={v => v.toLowerCase()}
          value={lowercase}
          onChange={setLowercase}
        >
          {renderInput}
        </Rifm>
```

And you can even replace with any text see new example.

```
        <Rifm
          accept={/./g}
          format={v => v}
          replace={v =>
            'Rifm is the best mask and formatting library. I love it! '
              .repeat(20)
              .slice(0, v.length)
          }
          value={capitalized}
          onChange={setCapitalized}
        >
          {renderInput}
        </Rifm>
```
