### PR TITLE
Remove useless warning

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 8097,
-    "minified": 1984,
-    "gzipped": 973
+    "bundled": 7885,
+    "minified": 1902,
+    "gzipped": 938
   },
   "dist/rifm.min.js": {
-    "bundled": 7276,
+    "bundled": 7250,
     "minified": 1583,
     "gzipped": 783
   },
   "dist/rifm.cjs.js": {
-    "bundled": 7780,
-    "minified": 2016,
-    "gzipped": 961
+    "bundled": 7442,
+    "minified": 1868,
+    "gzipped": 917
   },
   "dist/rifm.esm.js": {
-    "bundled": 7709,
-    "minified": 1953,
-    "gzipped": 917,
+    "bundled": 7371,
+    "minified": 1805,
+    "gzipped": 874,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,7 +29,7 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 6655,
+    "bundled": 6633,
     "minified": 1372,
     "gzipped": 667,
     "treeshaked": {

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -149,16 +149,6 @@ export const Rifm = (props: Props) => {
         // if nothing changed for formatted value, just refresh so userValue will be used at render
         refresh();
       } else {
-        if (process.env.NODE_ENV !== 'production') {
-          const replaceValue = replace
-            ? replace(formattedValue)
-            : formattedValue;
-
-          if (replaceValue.length !== formattedValue.length) {
-            console.warn('replace must preserve length');
-          }
-        }
-
         props.onChange(replace ? replace(formattedValue) : formattedValue);
       }
 


### PR DESCRIPTION
For masks with symbols like __-__-_____ replaced content is bigger vs original, and I can imagine situations where it can be less.
This warning is useless