### PR TITLE
chore: add package homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,10 @@
     "type": "git",
     "url": "https://github.com/istarkov/rifm.git"
   },
+  "homepage": "https://github.com/realadvisor/rifm#readme",
+  "bugs": {
+    "url": "https://github.com/realadvisor/rifm/issues"
+  },
   "resolutions": {
     "react": "~16.8.0",
     "react-dom": "~16.8.0"


### PR DESCRIPTION
## Summary

- Add npm `homepage` metadata pointing to the repository README
- Add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Notes

This is metadata-only. It does not change runtime code, dependencies, build output, exports, or package entry points.

## Verification

```text
node metadata assertion passed
git diff --check passed
```