### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "rifm",
   "version": "0.12.1",
+  "homepage": "https://github.com/realadvisor/rifm",
+  "bugs": {
+    "url": "https://github.com/realadvisor/rifm/issues"
+  },
   "description": "Tiny react input formatter and mask",
   "author": "istarkov",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.